### PR TITLE
fix: malformed environment variable JSON

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -27,7 +27,7 @@ CTP_LINE_ITEM_METADATA_TYPE_BODY="{ "key": "talon_one_line_item_metadata", "name
 CTP_CART_METADATA_TYPE_BODY="{"key":"talon_one_cart_metadata","name":{"en":"Talon.One Cart Metadata"},"resourceTypeIds":["order"],"fieldDefinitions":[{"name":"talon_one_cart_notifications","type":{"name":"String"},"required":false,"label":{"en":"Notifications"},"inputHint":"MultiLine"},{"name":"talon_one_cart_referral_code","type":{"name":"String"},"required":false,"label":{"en":"Referral Code"},"inputHint":"SingleLine"},{"name":"talon_one_cart_coupon_code_action","type":{"name":"String"},"required":false,"label":{"en":"Coupon Code Action"},"inputHint":"SingleLine"},{"name":"talon_one_cart_coupon_code_action_value","type":{"name":"String"},"required":false,"label":{"en":"Coupon Code Action Value"},"inputHint":"MultiLine"}]}"
 CTP_CUSTOMER_METADATA_TYPE_BODY="{"key":"talon_one_customer_metadata","name":{"en":"Talon.One Customer Metadata"},"resourceTypeIds":["customer"],"fieldDefinitions":[{"name":"talon_one_customer_referral_codes","type":{"name":"Set","elementType":{"name":"String"}},"required":false,"label":{"en":"Referral Codes"},"inputHint":"SingleLine"}]}"
 
-TALON_ONE_ATTRIBUTES_MAPPINGS="{ "customerProfile":{ "onlyVerifiedProfiles": true, "mappings":{ "commerceToolsAttributeOneName":"talonOneAttributeOneName", "commerceToolsAttributeTwoName":"talonOneAttributeTwoName", } } }"
+TALON_ONE_ATTRIBUTES_MAPPINGS="{ "customerProfile": { "onlyVerifiedProfiles": true, "mappings": { "commerceToolsAttributeOneName": "talonOneAttributeOneName", "commerceToolsAttributeTwoName": "talonOneAttributeTwoName" } } }"
 
 MIGRATION_BATCH_SIZE = "__REPLACE__"
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ AWS is the default.
   - `accessKey`: An AWS access key.
   - `accessSecret`: An AWS secret.
 
+**Important:** This variable contains a JSON object. Ensure it is valid JSON.
+
 To configure `accessKey` and `accessSecret` create another IAM user with minimal
 privileges. See an example in [`iam/ct-dev-iam.sample.json`](iam/ct-dev-iam.sample.json).
 Also see [AWS Lambda](https://docs.commercetools.com/api/projects/api-extensions#aws-lambda-destination).
@@ -115,6 +117,8 @@ Uncomment all commented variables under `For Google` and edit them:
 - `GCP_CREDENTIALS`: The absolute path to your Google service account credentials file created in the [Installing the tools section](#installing-the-tools).
 - `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`: for security reasons we need to set
   up basic authentication for the HTTP endpoint (same as in the first point)
+
+**Important:** This variable contains a JSON object. Ensure it is valid JSON.
 
 ##### Example
 
@@ -220,6 +224,8 @@ In the above example, the `CTP_POST_BODY` variable contains the following fields
 
    - `PAY_WITH_POINTS_ATTRIBUTE_NAME`: The name of the attribute to use to pay with loyalty points (e.g. `PayWithPoints`).
 
+**Important:** Some of these variables contain JSON data. Ensure it is valid JSON.
+
 ### Creating types in commercetools
 
 [Types define custom fields](https://docs.commercetools.com/api/projects/types) in commercetools.
@@ -295,6 +301,8 @@ To define the mapping, use the `TALON_ONE_ATTRIBUTES_MAPPINGS` env variable as a
 
 - The keys in the `mappings` object are commercetools fields.
 - The correpsonding values are Talon.One attributes.
+
+**Important:** This variable contains a JSON object. Ensure it is valid JSON.
 
 **Indented example:**
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,10 @@ This connector supports a list of
 [commercetools customer core fields](#supported-customer-commercetools-core-fields). Map the ones you
 need to their Talon.One equivalents that you created.
 
-To define the mapping, use the `TALON_ONE_ATTRIBUTES_MAPPINGS` env variable as a **one-line** JSON object.
+To define the mapping, use the `TALON_ONE_ATTRIBUTES_MAPPINGS` env variable as a **one-line** JSON object:
+
+- The keys in the `mappings` object are commercetools fields.
+- The correpsonding values are Talon.One attributes.
 
 **Indented example:**
 
@@ -311,6 +314,8 @@ commercetools with the following JSON:
 ```
 
 To see the supported customer core fields, see [Supported fields](docs/supported-fields.md).
+
+To map cart item attributes and cart item attributes, see [Data mapping examples](docs/data-mapping-examples.md).
 
 ## Testing your integration
 

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ In the above example, the `CTP_POST_BODY` variable contains the following fields
 
 ### Creating types in commercetools
 
-To support Talon.One-specific data, create custom types in commercetools. Run:
+[Types define custom fields](https://docs.commercetools.com/api/projects/types) in commercetools.
+To support Talon.One-specific data, run the following command to create the appropriate types:
 
 ```bash
 yarn register-api-types


### PR DESCRIPTION
### This Pull Request is a

- [ ] New feature
- [x] Bug fix
- [x] Documentation change
- [ ] Performance optimization
- [ ] Code refactoring
- [ ] Other: please add a description

### Problem 

Our suggested `.env.sample` had an invalid JSON value assigned to the `TALON_ONE_ATTRIBUTES_MAPPINGS` environment variable

### Solution 

Fixed that default value for the environment variable on the sample file

